### PR TITLE
L5.6 compliancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     },
     "require": {
         "laravel/tinker": "~1.0",
-        "illuminate/container": "5.2.* || 5.3.* || 5.4.* || 5.5.*"
+        "illuminate/container": "5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^6.4|^7.0"
     }
 }


### PR DESCRIPTION
The package isn't L5.6 compliant because of illuminate container dependency and phpunit not being updated.
Not really sure this updates will be enough to grant compliancy, but it's a start.