### PR TITLE
change comment type for blade minification

### DIFF
--- a/resources/views/includes.blade.php
+++ b/resources/views/includes.blade.php
@@ -58,7 +58,7 @@ function tinx_query($class, ...$args)
      * Zero arguments (i.e. u() returns "App\User").
      * */
     if ($totalArgs === 0) {
-        return $class; // Return a clean starting point for the query builder.
+        return $class; /* Return a clean starting point for the query builder. */
     }
 
     /**


### PR DESCRIPTION
Using the `htmlmin/htmlmin` package, the comment line breaks when the file is minified