### PR TITLE
Update composer.json for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "laravel/tinker": "~1.0",
-        "illuminate/container": "5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*"
+        "illuminate/container": "^5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4|^7.0"


### PR DESCRIPTION
This should allow usage of Tinx on 5.2 and all later versions.