### PR TITLE
Enable "u()" shortcut also for empty tables

### DIFF
--- a/resources/views/includes.blade.php
+++ b/resources/views/includes.blade.php
@@ -130,15 +130,16 @@ $latestColumn = '{{ array_get($config, 'latest_column', 'created_at') }}';
     try {
         ${!! $name !!} = {!! $class !!}::first() ?: app('{!! $class !!}');
         ${!! $name !!}_ = {!! $class !!}::latest($latestColumn)->first() ?: app('{!! $class !!}');
-        if (!function_exists('{!! $name !!}')) {
-            function {!! $name !!}(...$args) {
-                return tinx_query('{!! $class !!}', ...$args);
-            }
-        }
     } catch (Throwable $e) {
         @include('tinx::on-name-error')
     } catch (Exception $e) {
         @include('tinx::on-name-error')
+    }
+    
+    if (!function_exists('{!! $name !!}')) {
+        function {!! $name !!}(...$args) {
+            return tinx_query('{!! $class !!}', ...$args);
+        }
     }
 @endforeach
 unset($latestColumn);

--- a/resources/views/on-name-error.blade.php
+++ b/resources/views/on-name-error.blade.php
@@ -1,16 +1,18 @@
-@if ((bool) array_get($config, 'tableless_models'))
+@if ((bool) array_get($config, 'tableless_models') === true)
     try {
         ${!! $name !!} = app('{!! $class !!}');
         ${!! $name !!}_ = app('{!! $class !!}');
-        if (!function_exists('{!! $name !!}')) {
-            function {!! $name !!}(...$args) {
-                return '{!! $class !!}';
-            }
-        }
+        array_set($GLOBALS, 'tinx.shortcuts.{!! $name !!}', ${!! $name !!});
+        array_set($GLOBALS, 'tinx.shortcuts.{!! $name !!}_', ${!! $name !!}_);
     } catch (Throwable $e) {
         tinx_forget_name('{!! $class !!}');
     } catch (Exception $e) {
         tinx_forget_name('{!! $class !!}');
+    }
+    if (!function_exists('{!! $name !!}')) {
+        function {!! $name !!}(...$args) {
+            return '{!! $class !!}';
+        }
     }
 @else
     tinx_forget_name('{!! $class !!}');

--- a/src/Console/NamesTable.php
+++ b/src/Console/NamesTable.php
@@ -20,7 +20,7 @@ class NamesTable
     private function __construct(TinxCommand $command)
     {
         $this->command = $command;
-        $this->names = $this->command->getNames();
+        $this->names = array_get($GLOBALS, 'tinx.names');
     }
 
     /**
@@ -102,8 +102,8 @@ class NamesTable
      * */
     private function getRows()
     {
-        return collect($this->names)->map(function ($name, $class) {
-            return [$class, "\${$name}, \${$name}_, {$name}()"];
+        return collect($this->names)->map(function ($shortcuts, $class) {
+            return [$class, $shortcuts];
         });
     }
 

--- a/src/Console/TinxCommand.php
+++ b/src/Console/TinxCommand.php
@@ -47,7 +47,6 @@ class TinxCommand extends Command
             $this->rebootConfig();
             $this->setNames();
             $this->createTinxIncludes();
-            $this->conditionallyRenderNamesTable();
             $this->callTinker();
         } while (State::shouldRestart() && !$this->info("Reloading your tinker session..."));
 
@@ -71,19 +70,11 @@ class TinxCommand extends Command
     }
 
     /**
-     * @return array
-     * */
-    public function getNames()
-    {
-        return $this->names;
-    }
-
-    /**
      * @return void
      * */
     private function createTinxIncludes()
     {
-        with(new IncludeManager)->generateIncludesFile($this->getNames());
+        with(new IncludeManager)->generateIncludesFile($this->names);
     }
 
     /**
@@ -94,14 +85,10 @@ class TinxCommand extends Command
         app('events')->listen('tinx.names', function (...$args) {
             NamesTable::make($this)->render(...$args);
         });
-    }
 
-    /**
-     * @return void
-     * */
-    private function conditionallyRenderNamesTable()
-    {
-        NamesTable::make($this)->conditionallyRender();
+        app('events')->listen('tinx.names.conditional', function (...$args) {
+            NamesTable::make($this)->conditionallyRender();
+        });
     }
 
     /**


### PR DESCRIPTION
I was about to check out issue 50, but after testing
```
laravel new tinx-issue-50
composer require ajthinking/tinx
php artisan tinx
>>u()::someStatic()
```
I got ```PHP Fatal error:  Call to undefined function u() in Psy Shell code on line 1```

It seems the shortcut to `App\User` also required at least one item in the database. That makes sense for $u and $u_ but u() can be needed in other situations where table is still empty. Hence I moved it outside of the try block. What do you think?
