### PR TITLE
Fix for issue 69. Use fully qualified name for Arr in eval'd code

### DIFF
--- a/resources/views/includes.blade.php
+++ b/resources/views/includes.blade.php
@@ -126,7 +126,7 @@ function tinx_query($class, ...$args)
  * For "last" variable, returns "::latest()->first()" if class DB table exists, otherwise "new" (if 'tableless_models' set to true).
  * */
 Arr::set($GLOBALS, 'tinx.names', {!! var_export($names); !!});
-$latestColumn = '{{ Arr::get($config, 'latest_column', 'created_at') }}';
+$latestColumn = '{{ Illuminate\Support\Arr::get($config, 'latest_column', 'created_at') }}';
 @foreach ($names as $class => $name)
     try {
         ${!! $name !!} = {!! $class !!}::first() ?: app('{!! $class !!}');


### PR DESCRIPTION
Use fully qualified name for Arr in eval'd code as eval'd code doesn't have a namespace (it is executed as if in a new file).